### PR TITLE
Bugfix hardcoding the mailer

### DIFF
--- a/src/Command/MailSpoolCommand.php
+++ b/src/Command/MailSpoolCommand.php
@@ -37,6 +37,11 @@ class MailSpoolCommand extends BaseCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        if (!$this->app['swiftmailer.use_spool']) {
+            $output->write('<info>Spool is disabled</info>');
+            return;
+        }
+
         /** @var SwiftMailer $mailer */
         $mailer = $this->app['mailer'];
         /** @var SwiftTransportSpoolTransport $transport */

--- a/src/EmailSpoolerExtension.php
+++ b/src/EmailSpoolerExtension.php
@@ -6,8 +6,6 @@ use Bolt\Extension\SimpleExtension;
 use Pimple as Container;
 use Silex\Application;
 use Swift_FileSpool as SwiftFileSpool;
-use Swift_Mailer as SwiftMailer;
-use Swift_Transport_SpoolTransport as SwiftTransportSpoolTransport;
 
 /**
  * Email spooler extension loader.
@@ -21,15 +19,11 @@ class EmailSpoolerExtension extends SimpleExtension
      */
     protected function registerServices(Application $app)
     {
-        $app['mailer'] = $app->share(
-            function ($app) {
-                $app['mailer.initialized'] = true;
-                $spoolDir = $app['path_resolver']->resolve('%cache%/.spool');
-                $transport = new SwiftTransportSpoolTransport($app['swiftmailer.transport.eventdispatcher'], new SwiftFileSpool($spoolDir));
+        $app['swiftmailer.spool'] = $app->share(function ($app) {
+            $spoolDir = $app['path_resolver']->resolve('%cache%/.spool');
 
-                return new SwiftMailer($transport);
-            }
-        );
+            return new SwiftFileSpool($spoolDir);
+        });
 
         $app['mailer.queue.listener'] = $app->share(
             function ($app) {

--- a/src/EventListener/QueueListener.php
+++ b/src/EventListener/QueueListener.php
@@ -44,6 +44,10 @@ class QueueListener implements EventSubscriberInterface
      */
     public function flush(Event $event = null)
     {
+        if (!$this->app['swiftmailer.use_spool']) {
+            return;
+        }
+
         /** @var SwiftMailer $mailer */
         $mailer = $this->app['mailer'];
         /** @var SwiftTransportSpoolTransport $transport */
@@ -67,6 +71,10 @@ class QueueListener implements EventSubscriberInterface
      */
     public function retry()
     {
+        if (!$this->app['swiftmailer.use_spool']) {
+            return;
+        }
+
         $failedRecipients = [];
         /** @var SwiftMailer $mailer */
         $mailer = $this->app['mailer'];


### PR DESCRIPTION
Currently this extension hardcodes the mailer, breaking the `mailoptions` section of the config. This patch aims to fix this